### PR TITLE
Stephen/40-create service and api layers for sponsors

### DIFF
--- a/app/api/sponsor/route.ts
+++ b/app/api/sponsor/route.ts
@@ -1,0 +1,18 @@
+import { SponsorService } from "@/lib/service/SponsorService";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+    try {
+        const sponsors = await SponsorService.getSponsors();
+        return NextResponse.json(
+            { message: "Fetched all sponsors", data: sponsors },
+            { status: 200 },
+        );
+    } catch (error) {
+        console.error(error);
+        return NextResponse.json(
+            { error: "Failed to fetch sponsors" },
+            { status: 500 },
+        );
+    }
+}

--- a/lib/service/SponsorService.ts
+++ b/lib/service/SponsorService.ts
@@ -1,0 +1,11 @@
+import prisma from "@/lib/prisma";
+
+export class SponsorService {
+    static async getSponsors() {
+        return await prisma.sponsor.findMany({
+            include: {
+                SponsorTier: true,
+            },
+        });
+    }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -49,6 +49,8 @@ model Sponsor {
   id            Int         @id @default(autoincrement())
   createdAt     DateTime    @default(now())
   name          String      @unique
+  link          String
+  imageUrl      String      @map("image_url")
   sponsorTierId Int
   SponsorTier   SponsorTier @relation(fields: [sponsorTierId], references: [id])
 }


### PR DESCRIPTION
# What this PR does
Adds service and API layer for sponsors following the same architecture as events.

## Changes made
- Updated Sponsor schema with name, link and imageUrl fields
- Added dummy Sponsor and SponsorTier data to the database
- Created SponsorService class with getSponsors function
- Created /api/sponsor endpoint with error handling
- Tested with cURL to confirm endpoint returns sponsor data