### PR TITLE
Stephen/56-refactor-featured-events-to-show-last-3

### DIFF
--- a/app/api/events/featured/route.ts
+++ b/app/api/events/featured/route.ts
@@ -3,13 +3,26 @@ import { NextResponse } from "next/server";
 
 export async function GET() {
     try {
+        const today = new Date();
+        today.setHours(0, 0, 0, 0);
+
         const allEvents = await EventService.getEvents();
-        const featured = allEvents
+
+        const upcoming = allEvents
+            .filter((event: any) => new Date(event.date) >= today)
+            .sort(
+                (a: any, b: any) =>
+                    new Date(a.date).getTime() - new Date(b.date).getTime(),
+            );
+
+        const past = allEvents
+            .filter((event: any) => new Date(event.date) < today)
             .sort(
                 (a: any, b: any) =>
                     new Date(b.date).getTime() - new Date(a.date).getTime(),
-            )
-            .slice(0, 3);
+            );
+
+        const featured = [...upcoming, ...past].slice(0, 3);
 
         return NextResponse.json(
             { message: "Fetched featured events", data: featured },

--- a/app/api/events/featured/route.ts
+++ b/app/api/events/featured/route.ts
@@ -3,15 +3,11 @@ import { NextResponse } from "next/server";
 
 export async function GET() {
     try {
-        const today = new Date();
-        today.setHours(0, 0, 0, 0);
-
         const allEvents = await EventService.getEvents();
         const featured = allEvents
-            .filter((event: any) => new Date(event.date) >= today)
             .sort(
                 (a: any, b: any) =>
-                    new Date(a.date).getTime() - new Date(b.date).getTime(),
+                    new Date(b.date).getTime() - new Date(a.date).getTime(),
             )
             .slice(0, 3);
 


### PR DESCRIPTION
Closes #56

## Context
Currently the featured events section only shows upcoming events, which looks empty when there are no upcoming events scheduled.

## What Changed?
- Updated /api/events/featured route to prioritize upcoming events
- If there are enough upcoming events, shows the 3 soonest upcoming events
- If there aren't enough upcoming events, fills remaining slots with most recent past events

## How To Review
- Check app/api/events/featured/route.ts for the changes

## Testing
- Tested /api/events/featured endpoint in browser and confirmed it returns 3 events
- Confirmed homepage featured events section displays correct events

## Risks
N/A

## Notes
N/A