### PR TITLE
Stephen/72-connect-sponsor-section-to-database

### DIFF
--- a/app/components/SponsorCard.tsx
+++ b/app/components/SponsorCard.tsx
@@ -1,12 +1,16 @@
 type SponsorCardProps = {
-    link: string,
-    img: string
-}
+    link: string;
+    img: string;
+};
 
-export default function SponsorCard({link, img}: SponsorCardProps){
-    return(
+export default function SponsorCard({ link, img }: SponsorCardProps) {
+    return (
         <a className="sponsor-card" href={link} target="_blank">
-            <img className="sponsor-icon" src={img} alt="Company Logo" />
+            <img
+                className="sponsor-icon"
+                src={`${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/event_thumbnails/${img}`}
+                alt="Company Logo"
+            />
         </a>
-    )
+    );
 }

--- a/app/components/home/HomeClient.tsx
+++ b/app/components/home/HomeClient.tsx
@@ -6,9 +6,10 @@ import Sponsors from "./Sponsors";
 
 interface HomeClientProps {
     events: any[];
+    sponsors: any[];
 }
 
-export default function HomeClient({ events }: HomeClientProps) {
+export default function HomeClient({ events, sponsors}: HomeClientProps) {
     return (
         <>
             <Hero />
@@ -16,7 +17,7 @@ export default function HomeClient({ events }: HomeClientProps) {
             <div className="divider"></div>
             <About />
             <div className="divider"></div>
-            <Sponsors />
+            <Sponsors sponsors={sponsors} />
         </>
     );
 }

--- a/app/components/home/Sponsors.tsx
+++ b/app/components/home/Sponsors.tsx
@@ -1,29 +1,10 @@
 import SponsorCard from "../SponsorCard";
 
-// const sponsors = [
-//     {
-//         link: "https://www.facebook.com/StandingFierce/",
-//         img: "standing-fierce.webp",
-//     },
-//     {
-//         link: "https://zowie.benq.com/en-au/index.html",
-//         img: "zowie.webp",
-//     },
-//     {
-//         link: "https://gameon.co.nz/",
-//         img: "game-on.webp",
-//     },
-//     {
-//         link: "https://www.auckland.ac.nz/en/on-campus/facilities-and-services/sport-and-recreation/sport/EsportsArena.html",
-//         img: "esports-arena.webp",
-//     },
-// ];
-
 interface Sponsor {
     id: number;
     name: string;
     link: string;
-    imageUrl: string;
+    thumbnailPath: string;
 }
 
 export default function SponsorsSection({ sponsors }: { sponsors: Sponsor[] }) {
@@ -43,7 +24,7 @@ export default function SponsorsSection({ sponsors }: { sponsors: Sponsor[] }) {
                 {sponsors.map((sponsor) => (
                     <SponsorCard
                         link={sponsor.link}
-                        img={sponsor.imageUrl}
+                        img={sponsor.thumbnailPath}
                         key={sponsor.id}
                     />
                 ))}

--- a/app/components/home/Sponsors.tsx
+++ b/app/components/home/Sponsors.tsx
@@ -1,25 +1,32 @@
 import SponsorCard from "../SponsorCard";
 
-const sponsors = [
-    {
-        link: "https://www.facebook.com/StandingFierce/",
-        img: "standing-fierce.webp",
-    },
-    {
-        link: "https://zowie.benq.com/en-au/index.html",
-        img: "zowie.webp",
-    },
-    {
-        link: "https://gameon.co.nz/",
-        img: "game-on.webp",
-    },
-    {
-        link: "https://www.auckland.ac.nz/en/on-campus/facilities-and-services/sport-and-recreation/sport/EsportsArena.html",
-        img: "esports-arena.webp",
-    },
-];
+// const sponsors = [
+//     {
+//         link: "https://www.facebook.com/StandingFierce/",
+//         img: "standing-fierce.webp",
+//     },
+//     {
+//         link: "https://zowie.benq.com/en-au/index.html",
+//         img: "zowie.webp",
+//     },
+//     {
+//         link: "https://gameon.co.nz/",
+//         img: "game-on.webp",
+//     },
+//     {
+//         link: "https://www.auckland.ac.nz/en/on-campus/facilities-and-services/sport-and-recreation/sport/EsportsArena.html",
+//         img: "esports-arena.webp",
+//     },
+// ];
 
-export default function SponsorsSection() {
+interface Sponsor {
+    id: number;
+    name: string;
+    link: string;
+    imageUrl: string;
+}
+
+export default function SponsorsSection({ sponsors }: { sponsors: Sponsor[] }) {
     return (
         <section className="home-b">
             <div className="home-b-top">
@@ -33,11 +40,11 @@ export default function SponsorsSection() {
                 </a>
             </div>
             <div className="sponsor-wrapper">
-                {sponsors.map((sponsor, index) => (
+                {sponsors.map((sponsor) => (
                     <SponsorCard
                         link={sponsor.link}
-                        img={sponsor.img}
-                        key={index}
+                        img={sponsor.imageUrl}
+                        key={sponsor.id}
                     />
                 ))}
             </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,14 +1,17 @@
 import HomeClient from "./components/home/HomeClient";
 
 export default async function Home() {
-    const response = await fetch(
-        `${process.env.NEXT_PUBLIC_BASE_URL}/api/events/featured`,
-        {
+    const [eventsRes, sponsorsRes] = await Promise.all([
+        fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/events/featured`, {
             cache: "no-store",
-        },
-    );
-    const json = await response.json();
-    const events = json.data;
+        }),
+        fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/sponsor`, {
+            cache: "no-store",
+        }),
+    ]);
 
-    return <HomeClient events={events} />;
+    const events = (await eventsRes.json()).data;
+    const sponsors = (await sponsorsRes.json()).data;
+
+    return <HomeClient events={events} sponsors={sponsors} />;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,7 +11,7 @@ export default async function Home() {
     ]);
 
     const events = (await eventsRes.json()).data;
-    const sponsors = (await sponsorsRes.json()).data;
+    const sponsors = (await sponsorsRes.json()).data ?? [];
 
     return <HomeClient events={events} sponsors={sponsors} />;
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -50,7 +50,7 @@ model Sponsor {
   createdAt     DateTime    @default(now())
   name          String      @unique
   link          String
-  imageUrl      String      @map("image_url")
+  thumbnailPath String      
   sponsorTierId Int
   SponsorTier   SponsorTier @relation(fields: [sponsorTierId], references: [id])
 }


### PR DESCRIPTION
Closes #72

## Context
The sponsor section on the home page was using hardcoded data. This connects it to the existing Sponsor and SponsorTier tables in the database so sponsors can be managed dynamically.

## What Changed?
- Updated `app/api/sponsor/route.ts` API route to expose sponsor data
- Updated `app/page.tsx` to fetch sponsors alongside events
- Updated `HomeClient.tsx` to accept and pass sponsors as a prop
- Updated `Sponsors.tsx` to render sponsors from the database instead of hardcoded data

## How To Review
1. `prisma/schema.prisma` — Sponsor model 
2. `lib/service/SponsorService.ts` — database query
3. `app/api/sponsor/route.ts` — API route
4. `app/page.tsx` — fetching sponsors
5. `app/components/home/HomeClient.tsx` — passing sponsors as prop
6. `app/components/home/Sponsors.tsx` — rendering sponsors from database

## Testing
- Added the 4 previously hardcoded sponsors as rows in the database
- Verified the sponsors section renders correctly on the home page

## Risks
- If the database is unavailable the sponsors section will render empty rather than crashing due to the `?? []` fallback

## Notes
The sponsor tiers in the database for the 4 sponsors were set to 1 (Gold) if it is different will need to change