### PR TITLE
Stephen/rename-supabase-url

### DIFF
--- a/app/components/SponsorCard.tsx
+++ b/app/components/SponsorCard.tsx
@@ -8,7 +8,7 @@ export default function SponsorCard({ link, img }: SponsorCardProps) {
         <a className="sponsor-card" href={link} target="_blank">
             <img
                 className="sponsor-icon"
-                src={`${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/event_thumbnails/${img}`}
+                src={`${process.env.NEXT_PUBLIC_SUPABASE_OBJECT_STORAGE_URL}${img}`}
                 alt="Company Logo"
             />
         </a>


### PR DESCRIPTION
## Context
Renamed it to `NEXT_PUBLIC_SUPABASE_OBJECT_STORAGE_URL` and included the full bucket path to make it clearer and easier to use.

## What Changed?
- Updated `SponsorCard.tsx` to use the new env variable
- New env variable includes the full bucket path so the URL construction in code is simpler

## How To Review
2. `app/components/SponsorCard.tsx` — updated to use new env variable

## Testing
- Verified sponsor logos load correctly on the home page

## Risks
- Anyone running the project locally will need to update their `.env`